### PR TITLE
Update sync-repo.sh

### DIFF
--- a/sync-repo.sh
+++ b/sync-repo.sh
@@ -11,13 +11,13 @@
 echo "Synced changes with remote repository"
 
 # Pull changes from remote repository
-git pull origin main    
+git pull 
 
 # Stage all changes
-git stage .
+git add .
 
 # Commit changes with message 'Updated'
 git commit -m "Updated"
 
 # Push changes to remote repository on branch 'main'
-git push origin main
+git push 


### PR DESCRIPTION
This pull request includes a few small changes to the `sync-repo.sh` script to simplify the Git commands by removing explicit branch references.

Simplifications to Git commands:

* [`sync-repo.sh`](diffhunk://#diff-575d6743e8681b18ec441739763eeedfba8676be8c62e5756a5d94ce5cf81de4L14-R23): Removed explicit branch references from `git pull` and `git push` commands.
* [`sync-repo.sh`](diffhunk://#diff-575d6743e8681b18ec441739763eeedfba8676be8c62e5756a5d94ce5cf81de4L14-R23): Replaced `git stage .` with `git add .` to use the more common command for staging changes.